### PR TITLE
Excluded the documents directory.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,14 @@ name: Go
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+    
 
 jobs:
 


### PR DESCRIPTION
We don't need to handle builds on the document folder.  Might need to write a rule for markdown linting but not at this time.